### PR TITLE
Convert name of units from plural form to singular

### DIFF
--- a/lib/yabeda/datadog/units.rb
+++ b/lib/yabeda/datadog/units.rb
@@ -4,31 +4,44 @@ module Yabeda
   module Datadog
     # = The logic of working with Datadog units
     class Unit
+      # Datadog whitelist of units
       # source: https://docs.datadoghq.com/developers/metrics/#units
-      AVAILABLE = ["bit", "byte", "kibibyte", "mebibyte", "gibibyte", "tebibyte",
-                   "pebibyte", "exbibyte", "nanosecond", "microsecond", "millisecond",
-                   "second", "minute", "hour", "day", "week", "percent_nano", "percent",
-                   "apdex", "fraction", "connection", "request", "packet", "segment",
-                   "response", "message", "payload", "timeout", "datagram", "route",
-                   "session", "process", "thread", "host", "node", "fault", "service",
-                   "instance", "cpu", "file", "inode", "sector", "block", "buffer",
-                   "error", "read", "write", "occurrence", "event", "time", "unit",
-                   "operation", "item", "task", "worker", "resource", "garbage collection",
-                   "email", "sample", "stage", "monitor", "location", "check", "attempt",
-                   "device", "update", "method", "job", "container", "execution",
-                   "throttle", "invocation", "user", "success", "build", "prediction",
-                   "table", "index", "lock", "transaction", "query", "row", "key",
-                   "command", "offset", "record", "object", "cursor", "assertion", "scan",
-                   "document", "shard", "flush", "merge", "refresh", "fetch", "column",
-                   "commit", "wait", "ticket", "question", "hit", "miss", "eviction",
-                   "get", "set", "dollar", "cent", "page", "split", "hertz", "kilohertz",
-                   "megahertz", "gigahertz", "entry", "degree celsius", "degree fahrenheit",
-                   "nanocore", "microcore", "millicore", "core", "kilocore", "megacore",
-                   "gigacore", "teracore", "petacore", "exacore",].freeze
+      AVAILABLE = [
+        "bit", "byte", "kibibyte", "mebibyte", "gibibyte", "tebibyte",
+        "pebibyte", "exbibyte", "nanosecond", "microsecond", "millisecond",
+        "second", "minute", "hour", "day", "week", "percent_nano", "percent",
+        "apdex", "fraction", "connection", "request", "packet", "segment",
+        "response", "message", "payload", "timeout", "datagram", "route",
+        "session", "process", "thread", "host", "node", "fault", "service",
+        "instance", "cpu", "file", "inode", "sector", "block", "buffer",
+        "error", "read", "write", "occurrence", "event", "time", "unit",
+        "operation", "item", "task", "worker", "resource", "garbage collection",
+        "email", "sample", "stage", "monitor", "location", "check", "attempt",
+        "device", "update", "method", "job", "container", "execution",
+        "throttle", "invocation", "user", "success", "build", "prediction",
+        "table", "index", "lock", "transaction", "query", "row", "key",
+        "command", "offset", "record", "object", "cursor", "assertion", "scan",
+        "document", "shard", "flush", "merge", "refresh", "fetch", "column",
+        "commit", "wait", "ticket", "question", "hit", "miss", "eviction",
+        "get", "set", "dollar", "cent", "page", "split", "hertz", "kilohertz",
+        "megahertz", "gigahertz", "entry", "degree celsius", "degree fahrenheit",
+        "nanocore", "microcore", "millicore", "core", "kilocore", "megacore",
+        "gigacore", "teracore", "petacore", "exacore",
+      ].map { |unit| [unit, unit] }.to_h.freeze
 
-      # Find valid unit
+      IRREGULAR_PLURALS = {
+        "queries" => "query",
+        "entries" => "entry",
+        "indices" => "index",
+      }.freeze
+
+      # Find an available unit of metric
       def self.find(unit)
-        unit if unit && AVAILABLE.include?(unit)
+        unit_key = unit.to_s.downcase
+        AVAILABLE[unit_key] ||
+          AVAILABLE[unit_key.gsub(/s\z/, "")] ||
+          AVAILABLE[unit_key.gsub(/es\z/, "")] ||
+          IRREGULAR_PLURALS[unit_key]
       end
     end
   end

--- a/spec/yabeda/datadog/unit_spec.rb
+++ b/spec/yabeda/datadog/unit_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Yabeda::Datadog::Unit do
+  describe "::find" do
+    it "returns unit if it available on Datadog" do
+      expect(described_class.find("second")).to eq("second")
+    end
+
+    it "returns singular form of available unit" do
+      expect(described_class.find("seconds")).to eq("second")
+    end
+
+    it "accepts symbols" do
+      expect(described_class.find(:second)).to eq("second")
+    end
+
+    it "ignores case" do
+      expect(described_class.find("SECond")).to eq("second")
+    end
+
+    it "returns singular form for non standard unit" do
+      expect(described_class.find("fetches")).to eq("fetch")
+      expect(described_class.find("queries")).to eq("query")
+      expect(described_class.find("indices")).to eq("index")
+    end
+
+    it "returns nil if unit is not available" do
+      expect(described_class.find("abra cadabra")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Units may be defined in Yabeda configuration with units in plural form.

Since Datadog accepts units in the singular, we need to convert the names of units from plural forms to singular. This change will make using this adapter more enjoyable.

fixes #15 